### PR TITLE
Disable keybinds while editing inputs

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -74,12 +74,19 @@ const { soundLocked } = useSound();
 
 const showButtons = ref(false);
 
+function isInputFocused() {
+  const el = document.activeElement as HTMLElement | null;
+  return !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable);
+}
+
 function handleKeyDown(event: KeyboardEvent) {
+  if (isInputFocused()) return;
   if (event.key === 'Control') {
     showButtons.value = true;
   }
 }
 function handleKeyUp(event: KeyboardEvent) {
+  if (isInputFocused()) return;
   if (event.key === 'Control') {
     showButtons.value = false;
   }

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -212,8 +212,13 @@ function initGlobalTime(rtc: Rtc) {
   }, { immediate: true });
 
   /* ─────────────── 4. Keyboard shortcuts (lead only) ─────────────── */
+  function isInputFocused() {
+    const el = document.activeElement as HTMLElement | null;
+    return !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable);
+  }
+
   function handleKey(e: KeyboardEvent) {
-    if (!isLead.value) return;
+    if (!isLead.value || isInputFocused()) return;
     switch (e.code) {
       case 'Space':
         e.preventDefault();
@@ -248,7 +253,7 @@ function initGlobalTime(rtc: Rtc) {
   }
 
   function handleKeyUp(e: KeyboardEvent) {
-    if (!isLead.value) return;
+    if (!isLead.value || isInputFocused()) return;
     if (e.code === 'ArrowLeft' || e.code === 'ArrowRight') {
       debouncedSnapshot.flush();    // send final sync right away
     }


### PR DESCRIPTION
## Summary
- avoid triggering timer shortcuts when an input element has focus
- avoid showing/hiding control buttons if a field is selected

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aba7a72008323b8d9c87087614459