### PR TITLE
Add beep cue at 5s left in work

### DIFF
--- a/src/components/Timer.vue
+++ b/src/components/Timer.vue
@@ -89,6 +89,9 @@ watch(() => state.value.remainingSeconds, sec => {
   if (state.value.state === 'off' && [3, 2, 1].includes(sec)) {
     cue(String(sec) as CueKey);
   }
+  if (state.value.state === 'on' && sec === 5) {
+    beep(700, 180);
+  }
 });
 
 const formattedTimeInPhase = computed(() => formatTime(state.value.timeInPhase * 1000));


### PR DESCRIPTION
## Summary
- trigger a single beep when only 5 seconds remain in a work phase

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f9c25d8e0832381c8623e57c13904