### PR TITLE
Fix follower latency compensation

### DIFF
--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -172,9 +172,25 @@ function initGlobalTime(rtc: Rtc) {
       if (msg.config) timers.value = msg.config;
 
       if (msg.state) {
-        lastSnapshot.value = { timestamp: msg.timestamp, time: msg.state.time };
+        /*
+         * Use the local clock as the baseline for follower mode to
+         * avoid drift when the leader's and follower's system clocks
+         * are out of sync. Only the "time" from the leader matters for
+         * the follower, not the leader's timestamp.
+         *
+         * However, we still want to compensate for network latency. The
+         * timestamp included with the sync message tells us when the
+         * leader sent it. By adding the message age to `time`, the
+         * follower starts closer to the leader's current time.
+         */
+        const receivedAt = Date.now();
+        const msgAge = receivedAt - msg.timestamp;
+        lastSnapshot.value = {
+          timestamp: receivedAt,
+          time: msg.state.time + msgAge,
+        };
         ticking.value = msg.state.ticking;
-        now.value = msg.state.time;
+        now.value = msg.state.time + msgAge;
         msg.state.ticking ? resume(true) : pause(true);
       }
     });


### PR DESCRIPTION
## Summary
- tweak follower sync logic to account for message age

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f9f67527883239e8179c9554a214c