### PR TITLE
Make 5s warning beep optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ I thought that I could do better than that.
 
 - Multi-Team timer with individual offsets, work-time, rest-time and round count
 - Beep-Cues or Voice Cues per team
+- Optional 5‑second warning beep in work phases
 - Global color-coded phase overview with scrubber
 - Synchronisation with read-only instances (for showing on multiple devices)
 - Remote control

--- a/src/components/Timer.vue
+++ b/src/components/Timer.vue
@@ -15,6 +15,7 @@ export type TimerSettings = {
   rounds: number;   // work / rest cycles
   voice?: VoiceKey;
   color?: string;
+  warningBeep?: boolean; // beep 5s before work ends
 };
 
 const settings = defineModel<TimerSettings>('settings', {
@@ -88,6 +89,14 @@ watch(state, async (n, o) => {
 watch(() => state.value.remainingSeconds, sec => {
   if (state.value.state === 'off' && [3, 2, 1].includes(sec)) {
     cue(String(sec) as CueKey);
+  }
+  if (
+    state.value.state === 'on' &&
+    sec === 5 &&
+    globalTimeTicking.value &&
+    settings.value.warningBeep
+  ) {
+    beep(700, 180);
   }
 });
 
@@ -164,6 +173,14 @@ const showSettings = ref(false);
               </template>
               <template #unchecked>
                 Beep
+              </template>
+            </n-switch>
+            <n-switch v-model:value="settings.warningBeep">
+              <template #checked>
+                5s Beep
+              </template>
+              <template #unchecked>
+                No 5s
               </template>
             </n-switch>
           </div>

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -36,6 +36,7 @@ export function generateDefaultConfig(): KeyedTimerSettings[] {
         offTime: 30,
         rounds: 4,
         voice: 'M1',
+        warningBeep: true,
       },
     },
     {
@@ -47,6 +48,7 @@ export function generateDefaultConfig(): KeyedTimerSettings[] {
         offTime: 30,
         rounds: 4,
         voice: 'F1',
+        warningBeep: true,
       },
     },
   ];


### PR DESCRIPTION
## Summary
- add `warningBeep` to timer settings
- beep at 5s only when `warningBeep` is true
- allow toggling the warning beep alongside other cue options
- document warning beep in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9c25d8e0832381c8623e57c13904